### PR TITLE
Swaps out h2 for postgreSQL and adds Testcontainers for integration testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 #### Quickstart
 
+Ensure that you have a local instance of postgreSQL running. One way of doing this is by installing docker and running the following:
+
+    docker run --name postgresql -e POSTGRES_USER=dbuser -e POSTGRES_PASSWORD=dbpassword -p 5432:5432 -d postgres
+
+Make sure that the db credentials are consistent with those in `application.yaml`. Also ensure that the database `carasent_library` exists.
+
 Run `mvn spring-boot:run`. There are three users all with the same password `password` with security implemented using `BasicAuth`. The users are `john`, `user` and `admin`. It's recommended to browse the Postman collection to get an idea of how to make requests.
 
 #### Documentation
@@ -8,6 +14,10 @@ Here is a postman collection for the API:
 https://go.postman.co/collections/26384743-1300b272-655f-4129-9080-5655d2302d5f
 
 There is also some very basic and unfinished documentation in `src/main/asciidoc/documentation.adoc`.
+
+#### Tests
+
+Integration tests require docker to be installed as PostgreSQL containers are used in testing.
 
 #### Todo
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,14 +34,13 @@
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,12 +65,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers</artifactId>
 			<version>${testcontainers.version}</version>
 			<scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 	<description>Code test for Carasent</description>
 	<properties>
 		<java.version>17</java.version>
+		<testcontainers.version>1.18.0</testcontainers.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -60,6 +61,24 @@
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>${testcontainers.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<version>${testcontainers.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.jackson.property-naming-strategy=SNAKE_CASE

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,3 +2,7 @@
 spring:
   jackson:
     property-naming-strategy: SNAKE_CASE
+  datasource:
+    url: jdbc:postgresql://localhost:5432/carasent_library
+    username: dbuser
+    password: dbpassword

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,4 @@
+
+spring:
+  jackson:
+    property-naming-strategy: SNAKE_CASE

--- a/src/main/resources/db/changelog/book-setup.sql
+++ b/src/main/resources/db/changelog/book-setup.sql
@@ -1,5 +1,5 @@
 CREATE TABLE books (
-    id                  INT             PRIMARY KEY     AUTO_INCREMENT,
+    id                  SERIAL          PRIMARY KEY,
     title               VARCHAR(200)    NOT NULL,
     author              VARCHAR(200)    NOT NULL,
     year_of_purchase    SMALLINT        NOT NULL,

--- a/src/test/java/com/carasent/library/controller/BookApiDocumentation.java
+++ b/src/test/java/com/carasent/library/controller/BookApiDocumentation.java
@@ -1,5 +1,6 @@
 package com.carasent.library.controller;
 
+import com.carasent.testcontainers.EnablePostgresContainer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@EnablePostgresContainer
 @ExtendWith(RestDocumentationExtension.class)
 public class BookApiDocumentation {
 

--- a/src/test/java/com/carasent/library/controller/BorrowBookTest.java
+++ b/src/test/java/com/carasent/library/controller/BorrowBookTest.java
@@ -2,6 +2,7 @@ package com.carasent.library.controller;
 
 import com.carasent.library.model.Book;
 import com.carasent.library.repository.BookRepository;
+import com.carasent.testcontainers.EnablePostgresContainer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@EnablePostgresContainer
 public class BorrowBookTest extends LibraryWithBooksTestBase {
 
     @Autowired

--- a/src/test/java/com/carasent/library/controller/BorrowBookTest.java
+++ b/src/test/java/com/carasent/library/controller/BorrowBookTest.java
@@ -52,7 +52,7 @@ public class BorrowBookTest extends LibraryWithBooksTestBase {
         Map<String, String> patchUpdate = new LinkedHashMap<>();
         patchUpdate.put("borrowed_at", "2023-03-15 13:00:00");
 
-        Book book = bookRepository.findById(1).get();
+        Book book = bookRepository.findById(mostRecentId).get();
         mockMvc
                 .perform(
                         patch("/books/"+book.getId()).contentType(MediaType.APPLICATION_JSON)
@@ -73,7 +73,7 @@ public class BorrowBookTest extends LibraryWithBooksTestBase {
         Map<String, String> patchUpdate = new LinkedHashMap<>();
         patchUpdate.put("borrowed_at", null);
 
-        Book book = bookRepository.findById(1).get();
+        Book book = bookRepository.findById(mostRecentId.intValue()).get();
         mockMvc
                 .perform(
                         patch("/books/"+book.getId()).contentType(MediaType.APPLICATION_JSON)
@@ -93,7 +93,7 @@ public class BorrowBookTest extends LibraryWithBooksTestBase {
 
         Map<String, String> patchUpdate = new LinkedHashMap<>();
 
-        Book book = bookRepository.findById(5).get();
+        Book book = bookRepository.findById(mostRecentId).get();
         mockMvc
                 .perform(
                         patch("/books/"+book.getId()).contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/carasent/library/controller/CreateBookTest.java
+++ b/src/test/java/com/carasent/library/controller/CreateBookTest.java
@@ -1,5 +1,6 @@
 package com.carasent.library.controller;
 
+import com.carasent.testcontainers.EnablePostgresContainer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@EnablePostgresContainer
 public class CreateBookTest {
 
     @Autowired

--- a/src/test/java/com/carasent/library/controller/LibraryWithBooksTestBase.java
+++ b/src/test/java/com/carasent/library/controller/LibraryWithBooksTestBase.java
@@ -5,16 +5,19 @@ import com.carasent.library.repository.BookRepository;
 
 public class LibraryWithBooksTestBase {
 
+    protected Integer mostRecentId;
+
     public void populateBooks(BookRepository bookRepository){
 
-        if (bookRepository.count() >= 30) return;
+        bookRepository.deleteAll();
         for(short i=0; i<30; i++){
             Book book = new Book();
             book.setAuthor("Author"+i);
             book.setTitle("Title"+i);
             book.setCondition("NEW");
             book.setYearOfPurchase(i);
-            bookRepository.save(book);
+            Book savedBook = bookRepository.save(book);
+            mostRecentId = savedBook.getId().intValue();
         }
 
     }

--- a/src/test/java/com/carasent/library/controller/ListBooksTest.java
+++ b/src/test/java/com/carasent/library/controller/ListBooksTest.java
@@ -1,6 +1,7 @@
 package com.carasent.library.controller;
 
 import com.carasent.library.repository.BookRepository;
+import com.carasent.testcontainers.EnablePostgresContainer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@EnablePostgresContainer
 public class ListBooksTest extends LibraryWithBooksTestBase {
 
     @Autowired

--- a/src/test/java/com/carasent/library/controller/OverdueBooksTest.java
+++ b/src/test/java/com/carasent/library/controller/OverdueBooksTest.java
@@ -4,6 +4,7 @@ import com.carasent.library.model.Book;
 import com.carasent.library.repository.BookRepository;
 import com.carasent.library.service.BookService;
 import com.carasent.library.web.dto.BookPartialUpdate;
+import com.carasent.testcontainers.EnablePostgresContainer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@EnablePostgresContainer
 public class OverdueBooksTest extends LibraryWithBooksTestBase {
 
     @Autowired

--- a/src/test/java/com/carasent/testcontainers/EnablePostgresContainer.java
+++ b/src/test/java/com/carasent/testcontainers/EnablePostgresContainer.java
@@ -1,0 +1,14 @@
+package com.carasent.testcontainers;
+
+import org.springframework.test.context.ContextConfiguration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ContextConfiguration(initializers = PostgreSQLInitializer.class)
+public @interface EnablePostgresContainer {
+}

--- a/src/test/java/com/carasent/testcontainers/PostgreSQLInitializer.java
+++ b/src/test/java/com/carasent/testcontainers/PostgreSQLInitializer.java
@@ -1,0 +1,27 @@
+package com.carasent.testcontainers;
+
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public class PostgreSQLInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    public static PostgreSQLContainer postgreSQLContainer = new PostgreSQLContainer("postgres:15.2")
+            .withDatabaseName("library-test-db")
+            .withUsername("user")
+            .withPassword("password");
+
+    static {
+        postgreSQLContainer.start();
+    }
+
+    @Override
+    public void initialize(ConfigurableApplicationContext ctx) {
+        TestPropertyValues.of(
+                "spring.datasource.url=" + postgreSQLContainer.getJdbcUrl(),
+                "spring.datasource.username=" + postgreSQLContainer.getUsername(),
+                "spring.datasource.password=" + postgreSQLContainer.getPassword()
+        ).applyTo(ctx.getEnvironment());
+    }
+}


### PR DESCRIPTION
* Adds necessary Testcontainer & postgreSQL dependencies to `pom.xml`. Also removes H2 dependencies.
* Updates configuration and liquibase initialisation to be compatible with postgreSQL.
* Creates `@EnablePostgresContainer` annotation for enabling docker postgreSQL containers in tests.